### PR TITLE
Fix loop trigger in buffer player

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -41,9 +41,13 @@ s.options.maxNodes = 1024;
                         ~deckBuffers[key] = newBuf;
                         deck.set(\bufnum, newBuf.bufnum);
 
-                        // synchro avec le transport
-                        deck.set(\trig, 1);
-                        AppClock.sched(0.01, { deck.set(\trig, 0) });
+                        // synchro avec le transport (si le synth est actif)
+                        if(deck.isPlaying) {
+                            deck.set(\trig, 1);
+                            AppClock.sched(0.01, {
+                                if(deck.isPlaying) { deck.set(\trig, 0) }
+                            });
+                        };
 
                         ("[LOAD] Deck % → track % chargé : % (bufnum %, % frames, % canaux)")
                             .format(key, index, ~files[index].fileName, newBuf.bufnum, newBuf.numFrames, newBuf.numChannels)
@@ -78,6 +82,7 @@ s.options.maxNodes = 1024;
     ~deck2 = Synth(\bufferPlayer, [\bufnum, 0, \pitch, ~pitch, \amp, 0, \out, ~outputBus]);
     ~deck3 = Synth(\bufferPlayer, [\bufnum, 0, \pitch, ~pitch, \amp, 0, \out, ~outputBus]);
     ~deck4 = Synth(\bufferPlayer, [\bufnum, 0, \pitch, ~pitch, \amp, 0, \out, ~outputBus]);
+    s.sync;
 
     // fenêtre audio
     s.makeWindow;
@@ -91,10 +96,12 @@ s.options.maxNodes = 1024;
     ~transport = Routine({
         loop {
             [~deck1, ~deck2, ~deck3, ~deck4].do { |d|
-                if(d.notNil) {
+                if(d.notNil and: { d.isPlaying }) {
                     d.set(\trig, 1);
-                    AppClock.sched(0.01, { d.set(\trig, 0) });
-                }
+                    AppClock.sched(0.01, {
+                        if(d.isPlaying) { d.set(\trig, 0) }
+                    });
+                };
             };
             ~beatDur.wait;
         }

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -3,7 +3,7 @@ SynthDef(\bufferPlayer, {
     |out=0, bufnum=0, trig=1, pitch=1, amp=0.5,
      low=0, mid1=0, mid2=0, high=0,
      cue=0, cuegain=1,
-     loopOn=0, bpm=120,
+     loopOn=0, bpm=120, loopTrig=0,
      smoothTime=0.01, fadeTime=0.05| // fadeTime = fondu aux bords de la boucle
 
     var bufFrames, rate, measureDurSec, measureFrames;
@@ -11,7 +11,7 @@ SynthDef(\bufferPlayer, {
     var sigNormal, sigLoop, sig;
     var fadeFrames, fadeInLoop, fadeOutLoop, fadeEnvLoop;
     var loopOnLag, fadeEnvNormal, loopMixEnv;
-    var trigImpulse, crossEnv;
+    var trigImpulse, crossEnv, trigEvents;
 
     // === Infos buffer ===
     bufFrames = BufFrames.kr(bufnum);
@@ -22,7 +22,8 @@ SynthDef(\bufferPlayer, {
     measureFrames = measureDurSec * BufSampleRate.kr(bufnum);
 
     // === Trigger pour relancer la boucle ===
-    trigImpulse = Trig1.kr(Changed.kr(trig), 0.001);
+    trigEvents = HPZ1.kr(trig).max(0) + HPZ1.kr(loopTrig).max(0);
+    trigImpulse = Trig1.kr(trigEvents, 0.001);
 
     // === Phasor normal (lecture libre) ===
     phasorNormal = Phasor.ar(
@@ -62,7 +63,7 @@ SynthDef(\bufferPlayer, {
     sig = (sigNormal * fadeEnvNormal) + (sigLoop * loopMixEnv);
 
     // === Anti-clic supplémentaire lors d’un changement de trig ===
-    crossEnv = Lag.kr(Changed.kr(trig), smoothTime);
+    crossEnv = Lag.kr(trigEvents, smoothTime);
     sig = (sig * (1 - crossEnv)) + (sigLoop * crossEnv);
 
     // === EQ ===

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -56,10 +56,14 @@
         .background_(Color.black).knobColor_(Color.white)
         .action_({ |sl|
             var val = sl.value.asInteger;
-            ~deck1.set(\loopOn, val);
-            if(val == 1) {
-                ~deck1.set(\loopTrig, 1);
-                AppClock.sched(0.01, { ~deck1.set(\loopTrig, 0) });
+            if(~deck1.notNil and: { ~deck1.isPlaying }) {
+                ~deck1.set(\loopOn, val);
+                if(val == 1) {
+                    ~deck1.set(\loopTrig, 1);
+                    AppClock.sched(0.01, {
+                        if(~deck1.notNil and: { ~deck1.isPlaying }) { ~deck1.set(\loopTrig, 0) }
+                    });
+                };
             };
             loopLabel1.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
@@ -83,10 +87,14 @@
         .background_(Color.black).knobColor_(Color.white)
         .action_({ |sl|
             var val = sl.value.asInteger;
-            ~deck2.set(\loopOn, val);
-            if(val == 1) {
-                ~deck2.set(\loopTrig, 1);
-                AppClock.sched(0.01, { ~deck2.set(\loopTrig, 0) });
+            if(~deck2.notNil and: { ~deck2.isPlaying }) {
+                ~deck2.set(\loopOn, val);
+                if(val == 1) {
+                    ~deck2.set(\loopTrig, 1);
+                    AppClock.sched(0.01, {
+                        if(~deck2.notNil and: { ~deck2.isPlaying }) { ~deck2.set(\loopTrig, 0) }
+                    });
+                };
             };
             loopLabel2.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
@@ -110,10 +118,14 @@
         .background_(Color.black).knobColor_(Color.white)
         .action_({ |sl|
             var val = sl.value.asInteger;
-            ~deck3.set(\loopOn, val);
-            if(val == 1) {
-                ~deck3.set(\loopTrig, 1);
-                AppClock.sched(0.01, { ~deck3.set(\loopTrig, 0) });
+            if(~deck3.notNil and: { ~deck3.isPlaying }) {
+                ~deck3.set(\loopOn, val);
+                if(val == 1) {
+                    ~deck3.set(\loopTrig, 1);
+                    AppClock.sched(0.01, {
+                        if(~deck3.notNil and: { ~deck3.isPlaying }) { ~deck3.set(\loopTrig, 0) }
+                    });
+                };
             };
             loopLabel3.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
@@ -137,10 +149,14 @@
         .background_(Color.black).knobColor_(Color.white)
         .action_({ |sl|
             var val = sl.value.asInteger;
-            ~deck4.set(\loopOn, val);
-            if(val == 1) {
-                ~deck4.set(\loopTrig, 1);
-                AppClock.sched(0.01, { ~deck4.set(\loopTrig, 0) });
+            if(~deck4.notNil and: { ~deck4.isPlaying }) {
+                ~deck4.set(\loopOn, val);
+                if(val == 1) {
+                    ~deck4.set(\loopTrig, 1);
+                    AppClock.sched(0.01, {
+                        if(~deck4.notNil and: { ~deck4.isPlaying }) { ~deck4.set(\loopTrig, 0) }
+                    });
+                };
             };
             loopLabel4.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });


### PR DESCRIPTION
## Summary
- add loopTrig parameter to buffer player synth
- trigger loops and anti-click envelope on dedicated control
- prevent `/n_set Node ... not found` spam by waiting for synth creation and checking `isPlaying`

## Testing
- `which sclang` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d275e2b483338f88080fc4c4392f