### PR TITLE
Add selectable loop lengths for buffer players

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -3,10 +3,10 @@ SynthDef(\bufferPlayer, {
     |out=0, bufnum=0, trig=1, pitch=1, amp=0.5,
      low=0, mid1=0, mid2=0, high=0,
      cue=0, cuegain=1,
-     loopOn=0, bpm=120, loopTrig=0,
+     loopOn=0, bpm=120, loopTrig=0, loopBeats=4,
      smoothTime=0.03, fadeTime=0.12| // fadeTime = fondu aux bords de la boucle
 
-    var bufFrames, rate, measureDurSec, measureFrames;
+    var bufFrames, rate, beatDurSec, loopDurSec, loopFrames;
     var phasorNormal, loopStart, loopEnd, phasorLoop;
     var sigNormal, sigLoop, sig;
     var fadeFrames, fadeInLoop, fadeOutLoop, fadeEnvLoop;
@@ -17,10 +17,12 @@ SynthDef(\bufferPlayer, {
     bufFrames = BufFrames.kr(bufnum);
     rate = BufRateScale.kr(bufnum) * pitch;
 
-    // === Durée d'une mesure en frames (4 temps) ===
-    measureDurSec = (60 / bpm) * 4;
-    // ajuster la longueur de mesure selon le pitch pour garder une durée fixe
-    measureFrames = measureDurSec * BufSampleRate.kr(bufnum) * pitch;
+    // === Durée de boucle en frames ===
+    beatDurSec = 60 / bpm;
+    loopBeats = loopBeats.max(1); // sécurité contre les valeurs nulles
+    loopDurSec = beatDurSec * loopBeats;
+    // ajuster la longueur de boucle selon le pitch pour garder une durée fixe
+    loopFrames = loopDurSec * BufSampleRate.kr(bufnum) * pitch;
 
     // === Trigger pour relancer la boucle ===
     trigEvents = HPZ1.kr(trig).max(0) + HPZ1.kr(loopTrig).max(0);
@@ -35,7 +37,7 @@ SynthDef(\bufferPlayer, {
 
     // === Points de boucle latched sur le trigger ===
     loopStart = Latch.kr(phasorNormal, trigImpulse);
-    loopEnd   = loopStart + measureFrames;
+    loopEnd   = loopStart + loopFrames;
 
     // === Phasor en mode boucle ===
     phasorLoop = Phasor.ar(

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -2,11 +2,11 @@
     var window, bufferNames,
     textDeck1, textDeck2, textDeck3, textDeck4,
     listDeck1, listDeck2, listDeck3, listDeck4,
-    loopSlider1, loopLabel1, resyncButton1,
-    loopSlider2, loopLabel2, resyncButton2,
-    loopSlider3, loopLabel3, resyncButton3,
-    loopSlider4, loopLabel4, resyncButton4,
-    freqscope;
+    loopSlider1, loopLabel1, loopLengthLabel1, loopLengthMenu1, resyncButton1,
+    loopSlider2, loopLabel2, loopLengthLabel2, loopLengthMenu2, resyncButton2,
+    loopSlider3, loopLabel3, loopLengthLabel3, loopLengthMenu3, resyncButton3,
+    loopSlider4, loopLabel4, loopLengthLabel4, loopLengthMenu4, resyncButton4,
+    freqscope, loopLengthChoices, loopLengthLabels, updateLoopLength;
 
     var applyDarkStyle = { |view|
         view.background_(Color.black).stringColor_(Color.white);
@@ -44,6 +44,24 @@
     window = Window.new("Buffer Selector", Rect(100, 100, 500, 400))
         .background_(Color.black);
 
+    // Options de longueur de boucle
+    loopLengthChoices = [1, 2, 4];
+    loopLengthLabels = ["1 temps", "2 temps", "1 mesure"];
+
+    updateLoopLength = { |deck, slider, label, menu|
+        var index = menu.value;
+        if(index.isNil) { index = 2 }; // valeur par défaut : 1 mesure
+        index = index.clip(0, loopLengthChoices.size - 1);
+        menu.value = index;
+        var beats = loopLengthChoices[index];
+        deck.set(\loopBeats, beats);
+        label.string = "Durée boucle: " ++ loopLengthLabels[index];
+        if(slider.value.asInteger == 1) {
+            deck.set(\loopTrig, 1);
+            AppClock.sched(0.01, { deck.set(\loopTrig, 0) });
+        };
+    };
+
     // --- Deck 1 ---
     textDeck1 = StaticText(window).string_("Player Y Buffer:"); applyDarkStyle.(textDeck1);
     listDeck1 = PopUpMenu(window)
@@ -70,7 +88,14 @@
             };
             loopLabel1.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
-        resyncButton1 = Button(window)
+    loopLengthLabel1 = StaticText(window).string_("Durée boucle: 1 mesure"); applyDarkStyle.(loopLengthLabel1);
+    loopLengthMenu1 = PopUpMenu(window)
+        .items_(loopLengthLabels)
+        .background_(Color.black)
+        .stringColor_(Color.white)
+        .value_(2)
+        .action_({ |menu| updateLoopLength.(~deck1, loopSlider1, loopLengthLabel1, menu) });
+    resyncButton1 = Button(window)
         .states_([["Resync", Color.white, Color.black]])
         .action_({ resyncDeck.(~deck1) });
 
@@ -100,7 +125,14 @@
             };
             loopLabel2.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
-        resyncButton2 = Button(window)
+    loopLengthLabel2 = StaticText(window).string_("Durée boucle: 1 mesure"); applyDarkStyle.(loopLengthLabel2);
+    loopLengthMenu2 = PopUpMenu(window)
+        .items_(loopLengthLabels)
+        .background_(Color.black)
+        .stringColor_(Color.white)
+        .value_(2)
+        .action_({ |menu| updateLoopLength.(~deck2, loopSlider2, loopLengthLabel2, menu) });
+    resyncButton2 = Button(window)
         .states_([["Resync", Color.white, Color.black]])
         .action_({ resyncDeck.(~deck2) });
 
@@ -130,7 +162,14 @@
             };
             loopLabel3.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
-        resyncButton3 = Button(window)
+    loopLengthLabel3 = StaticText(window).string_("Durée boucle: 1 mesure"); applyDarkStyle.(loopLengthLabel3);
+    loopLengthMenu3 = PopUpMenu(window)
+        .items_(loopLengthLabels)
+        .background_(Color.black)
+        .stringColor_(Color.white)
+        .value_(2)
+        .action_({ |menu| updateLoopLength.(~deck3, loopSlider3, loopLengthLabel3, menu) });
+    resyncButton3 = Button(window)
         .states_([["Resync", Color.white, Color.black]])
         .action_({ resyncDeck.(~deck3) });
 
@@ -160,7 +199,14 @@
             };
             loopLabel4.string = if(val == 1) { "Loop ON" } { "Loop OFF" };
         });
-        resyncButton4 = Button(window)
+    loopLengthLabel4 = StaticText(window).string_("Durée boucle: 1 mesure"); applyDarkStyle.(loopLengthLabel4);
+    loopLengthMenu4 = PopUpMenu(window)
+        .items_(loopLengthLabels)
+        .background_(Color.black)
+        .stringColor_(Color.white)
+        .value_(2)
+        .action_({ |menu| updateLoopLength.(~deck4, loopSlider4, loopLengthLabel4, menu) });
+    resyncButton4 = Button(window)
         .states_([["Resync", Color.white, Color.black]])
         .action_({ resyncDeck.(~deck4) });
 
@@ -172,10 +218,10 @@
     window.layout_(
         VLayout(
             HLayout(
-                VLayout(textDeck1, listDeck1, loopLabel1, loopSlider1, resyncButton1),
-                VLayout(textDeck2, listDeck2, loopLabel2, loopSlider2, resyncButton2),
-                VLayout(textDeck3, listDeck3, loopLabel3, loopSlider3, resyncButton3),
-                VLayout(textDeck4, listDeck4, loopLabel4, loopSlider4, resyncButton4)
+                VLayout(textDeck1, listDeck1, loopLabel1, loopSlider1, loopLengthLabel1, loopLengthMenu1, resyncButton1),
+                VLayout(textDeck2, listDeck2, loopLabel2, loopSlider2, loopLengthLabel2, loopLengthMenu2, resyncButton2),
+                VLayout(textDeck3, listDeck3, loopLabel3, loopSlider3, loopLengthLabel3, loopLengthMenu3, resyncButton3),
+                VLayout(textDeck4, listDeck4, loopLabel4, loopSlider4, loopLengthLabel4, loopLengthMenu4, resyncButton4)
             ),
             freqscope
         )


### PR DESCRIPTION
## Summary
- add a loopBeats parameter to the buffer player synth to support multiple loop durations
- expose loop length selection in the UI with preset options for 1 beat, 2 beats, or a full measure
- automatically retrigger the active loop when changing its duration to keep playback in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9d2cb1048333a5c122dcf2d75cfe