### PR TITLE
Improve loop retriggering behaviour

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -8,10 +8,11 @@ SynthDef(\bufferPlayer, {
 
     var bufFrames, rate, beatDurSec, loopDurSec, loopFrames;
     var phasorNormal, loopStart, loopEnd, phasorLoop;
-    var sigNormal, sigLoop, sig;
+    var sigNormal, sigLoopRaw, sigLoop, sig;
     var fadeFrames, fadeInLoop, fadeOutLoop, fadeEnvLoop;
     var loopOnLag, fadeEnvNormal, loopMixEnv;
     var trigImpulse, crossEnv, trigEvents;
+    var fadeSafeTime, loopDelayed, retrigEnv;
 
     // === Infos buffer ===
     bufFrames = BufFrames.kr(bufnum);
@@ -49,15 +50,21 @@ SynthDef(\bufferPlayer, {
     );
 
     // === Lecture audio ===
-    sigNormal = BufRd.ar(2, bufnum, phasorNormal, loop: 1);
-    sigLoop   = BufRd.ar(2, bufnum, phasorLoop, loop: 1);
+    sigNormal   = BufRd.ar(2, bufnum, phasorNormal, loop: 1);
+    sigLoopRaw  = BufRd.ar(2, bufnum, phasorLoop, loop: 1);
 
     // === Fade sur les bords de la boucle ===
     fadeFrames = fadeTime * BufSampleRate.kr(bufnum);
     fadeInLoop  = ((phasorLoop - loopStart) / fadeFrames).clip(0, 1);
     fadeOutLoop = ((loopEnd - phasorLoop) / fadeFrames).clip(0, 1);
     fadeEnvLoop = fadeInLoop * fadeOutLoop;
-    sigLoop = sigLoop * fadeEnvLoop;
+    sigLoopRaw = sigLoopRaw * fadeEnvLoop;
+
+    // === Fondu court lors d’un re-trigger pour éviter les clics ===
+    fadeSafeTime = fadeTime.max(0.001);
+    loopDelayed  = DelayN.ar(sigLoopRaw, fadeSafeTime, fadeSafeTime);
+    retrigEnv    = Decay2.kr(trigImpulse, 0.001, fadeSafeTime);
+    sigLoop      = (sigLoopRaw * (1 - retrigEnv)) + (loopDelayed * retrigEnv);
 
     // === Crossfade normal <-> loop ===
     loopOnLag     = LagUD.kr(loopOn, fadeTime, fadeTime);

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -6,15 +6,24 @@
     loopSlider2, loopLabel2, loopLengthLabel2, resyncButton2,
     loopSlider3, loopLabel3, loopLengthLabel3, resyncButton3,
     loopSlider4, loopLabel4, loopLengthLabel4, resyncButton4,
-    freqscope, loopLengthChoices, loopLengthLabels, updateLoopControl;
+    freqscope, loopLengthChoices, loopLengthLabels, updateLoopControl,
+    sendPulse;
 
     var applyDarkStyle = { |view|
         view.background_(Color.black).stringColor_(Color.white);
     };
 
+    sendPulse = { |deck, param, hold = 0.02|
+        if(deck.notNil and: { deck.isPlaying }) {
+            deck.set(param, 1);
+            AppClock.sched(hold, {
+                if(deck.isPlaying) { deck.set(param, 0) };
+            });
+        };
+    };
+
     var resyncDeck = { |deck|
-        deck.set(\trig, 1);
-        AppClock.sched(0.01, { deck.set(\trig, 0) });
+        sendPulse.(deck, \trig);
     };
 
     bufferNames = ~files.collect { |file| file.fileName };
@@ -62,6 +71,7 @@
             var beats = loopLengthChoices[index];
             deck.set(\loopOn, 1);
             deck.set(\loopBeats, beats);
+            sendPulse.(deck, \loopTrig);
             statusLabel.string = "Loop ON";
             lengthLabel.string = "Durée boucle: " ++ loopLengthLabels[index];
         };


### PR DESCRIPTION
## Summary
- add a short crossfade around loop retriggers to keep playback smooth and avoid clicks
- pulse the loop trigger from the UI whenever loop length changes so looping restarts from the current playhead

## Testing
- not run (SuperCollider runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68daa490a4e48333a48675a6f2821f1e