### PR TITLE
Fix loop activation to capture current playback position

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -69,9 +69,17 @@
         } {
             var index = value - 1;
             var beats = loopLengthChoices[index];
-            deck.set(\loopOn, 1);
+
             deck.set(\loopBeats, beats);
+
+            // capturer la position de lecture AVANT d’activer le crossfade
             sendPulse.(deck, \loopTrig);
+
+            // activer la boucle une fois la position mémorisée
+            AppClock.sched(0, {
+                if(deck.notNil) { deck.set(\loopOn, 1) };
+            });
+
             statusLabel.string = "Loop ON";
             lengthLabel.string = "Durée boucle: " ++ loopLengthLabels[index];
         };


### PR DESCRIPTION
## Summary
- ensure the loop trigger pulse is sent before enabling the crossfade
- delay the loop activation until after the current playhead position is latched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa7b26b98833389977461cbfd6aeb